### PR TITLE
Add Name and Message fields to flattenedEmailVars in mailservice

### DIFF
--- a/satellite/mailservice/service.go
+++ b/satellite/mailservice/service.go
@@ -106,6 +106,8 @@ type flattenedEmailVars struct {
 	SignInLink            string
 	ContactInfoURL        string
 	TermsAndConditionsURL string
+	Name                  string
+	Message               string
 }
 
 // copyStringField sets dst to the string value of v.FieldByName(fieldName) if the field exists and is a string.
@@ -225,6 +227,8 @@ func (service *Service) SendRendered(ctx context.Context, to []post.Address, msg
 			copyStringField(&flatVars.SignInLink, v, "SignInLink")
 			copyStringField(&flatVars.ContactInfoURL, v, "ContactInfoURL")
 			copyStringField(&flatVars.TermsAndConditionsURL, v, "TermsAndConditionsURL")
+			copyStringField(&flatVars.Name, v, "Name")
+			copyStringField(&flatVars.Message, v, "Message")
 		}
 	}
 	templateData := &flatVars


### PR DESCRIPTION
- Introduced new fields `Name` and `Message` to the `flattenedEmailVars` struct for enhanced email customization.
- Updated the `SendRendered` function to copy values for the new fields from the provided context.

These changes improve the flexibility of email rendering by allowing additional personalized content.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
