### PR TITLE
Refactor node reputation query to remove redundant field

### DIFF
--- a/satellite/satellitedb/nodereputation.go
+++ b/satellite/satellitedb/nodereputation.go
@@ -31,7 +31,7 @@ func (nr *nodeReputation) GetAll(ctx context.Context) (reputations []audit.NodeR
 	defer mon.Task()(&ctx)(&err)
 
 	rows, err := nr.db.QueryContext(ctx, `SELECT n.id, n.wallet, n.disqualified, n.exit_initiated_at, n.exit_finished_at,
-										n.exit_success, n.under_review, n.inactive, r.audit_reputation_alpha, r.disqualified,
+										n.exit_success, n.under_review, n.inactive, r.audit_reputation_alpha,
 										n.piece_count, n.last_contact_success
                                     FROM reputations r
                                     INNER JOIN nodes n on n.id = r.id;`)
@@ -45,7 +45,7 @@ func (nr *nodeReputation) GetAll(ctx context.Context) (reputations []audit.NodeR
 		err = rows.Scan(&reputation.NodeID, &reputation.Wallet, &reputation.Disqualified,
 			&reputation.ExitInitiatedAt, &reputation.ExitFinishedAt, &reputation.ExitSuccess,
 			&reputation.UnderReview, &reputation.Inactive, &reputation.AuditReputationAlpha,
-			&reputation.Disqualified, &reputation.PieceCount, &reputation.LastContactSuccess)
+			&reputation.PieceCount, &reputation.LastContactSuccess)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Updated the SQL query in the `GetAll` method of the `nodeReputation` struct to eliminate the redundant `disqualified` field from the selection.
- Adjusted the corresponding `rows.Scan` method to reflect this change, improving data handling efficiency.

These modifications streamline the data retrieval process for node reputations.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
