### PR TITLE
Add node reputation handling for inactive nodes

### DIFF
--- a/satellite/audit/reputationpushworker.go
+++ b/satellite/audit/reputationpushworker.go
@@ -177,6 +177,12 @@ func (worker *ReputationPushWorker) calculateReputationValue(ctx context.Context
 		worker.db.NodeSmartContractStatus(ctx, reputation.Wallet, "info", "node is inactive because: "+string(reputationJson))
 	}
 
+	// Nodes that stopped contacting for over 30 days should be pushed with a minimum score.
+	if worker.isNodeOlderThan30Days(reputation) {
+		worker.log.Info("node last contact older than 30 days, forcing reputation to 5", zap.String("wallet", reputation.Wallet))
+		return 5
+	}
+
 	return reputationVal
 }
 
@@ -192,7 +198,12 @@ func (worker *ReputationPushWorker) isNodeDisqualified(reputation NodeReputation
 // isNodeInactive checks if a node is considered inactive.
 func (worker *ReputationPushWorker) isNodeInactive(reputation NodeReputationEntry) bool {
 	return reputation.LastContactSuccess == nil ||
-		reputation.PieceCount == 0 ||
+		reputation.PieceCount == 0
+}
+
+// isNodeOlderThan30Days checks if last successful contact is older than 30 days.
+func (worker *ReputationPushWorker) isNodeOlderThan30Days(reputation NodeReputationEntry) bool {
+	return reputation.LastContactSuccess != nil &&
 		reputation.LastContactSuccess.Before(time.Now().Add(-time.Hour*24*30))
 }
 


### PR DESCRIPTION
- Implemented a check to force a minimum reputation score of 5 for nodes that have not contacted for over 30 days, improving the accuracy of reputation assessments.
- Introduced a new helper function, `isNodeOlderThan30Days`, to encapsulate the logic for determining node inactivity based on last contact time.

These changes enhance the reliability of the reputation system by ensuring long-inactive nodes are appropriately scored.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
