### PR TITLE
Update reputation handling for inactive nodes

### DIFF
--- a/satellite/audit/reputationpushworker.go
+++ b/satellite/audit/reputationpushworker.go
@@ -180,7 +180,7 @@ func (worker *ReputationPushWorker) calculateReputationValue(ctx context.Context
 	// Nodes that stopped contacting for over 30 days should be pushed with a minimum score.
 	if worker.isNodeOlderThan30Days(reputation) {
 		worker.log.Info("node last contact older than 30 days, forcing reputation to 5", zap.String("wallet", reputation.Wallet))
-		return 5
+		// return 5 //for now, we are not forcing the reputation to 5 (we are keeping the default reputation)
 	}
 
 	return reputationVal


### PR DESCRIPTION
- Commented out the forced minimum reputation score of 5 for nodes inactive over 30 days, retaining the default reputation value for now.
- This change allows for further evaluation of the reputation scoring logic without enforcing a minimum score.

These modifications provide flexibility in the reputation assessment process for long-inactive nodes.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
