### PR TITLE
Update reputation scoring logic for recent node activity

### DIFF
--- a/satellite/audit/reputationpushworker.go
+++ b/satellite/audit/reputationpushworker.go
@@ -217,9 +217,9 @@ func (worker *ReputationPushWorker) calculateReputationValue(ctx context.Context
 	}
 
 	// Nodes that stopped contacting for over 30 days should be pushed with a minimum score.
-	if worker.isNodeOlderThan30Days(reputation) {
-		worker.log.Info("node last contact older than 30 days, forcing reputation to 5", zap.String("wallet", reputation.Wallet))
-		// return 5 //for now, we are not forcing the reputation to 5 (we are keeping the default reputation)
+	if worker.isNodeOlderThan24Hours(reputation) {
+		worker.log.Info("node last contact older than 24 hours, forcing reputation to 5", zap.String("wallet", reputation.Wallet))
+		return 5
 	}
 
 	return reputationVal
@@ -241,9 +241,9 @@ func (worker *ReputationPushWorker) isNodeInactive(reputation NodeReputationEntr
 }
 
 // isNodeOlderThan30Days checks if last successful contact is older than 30 days.
-func (worker *ReputationPushWorker) isNodeOlderThan30Days(reputation NodeReputationEntry) bool {
+func (worker *ReputationPushWorker) isNodeOlderThan24Hours(reputation NodeReputationEntry) bool {
 	return reputation.LastContactSuccess != nil &&
-		reputation.LastContactSuccess.Before(time.Now().Add(-time.Hour*24*30))
+		reputation.LastContactSuccess.Before(time.Now().Add(-time.Hour*24))
 }
 
 // handleInactiveNode handles inactive nodes by checking if they're stakers, adding them if needed, and activating them.


### PR DESCRIPTION
- Modified the `ReputationPushWorker` to force a minimum reputation score of 5 for nodes that have not contacted in over 24 hours, enhancing the responsiveness of the reputation system.
- Renamed the helper function to `isNodeOlderThan24Hours` to reflect the updated inactivity threshold.

These changes improve the accuracy of reputation assessments for recently inactive nodes, ensuring timely adjustments to their scores.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
