### PR TITLE
satellite/satellitedb: fix GetAllParticipatingNodes row scan alignment

### DIFF
--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -728,6 +728,9 @@ func (cache *overlaycache) GetAllParticipatingNodes(ctx context.Context, onlineW
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, Error.Wrap(err)
+	}
 
 	err = cache.addNodeTagsFromFullScan(ctx, nodes)
 	if err != nil {
@@ -939,10 +942,11 @@ func scanSelectedNode(rows tagsql.Rows) (nodeselection.SelectedNode, error) {
 	var node nodeselection.SelectedNode
 	node.Address = &pb.NodeAddress{}
 	var lastIPPort, countryCode sql.NullString
+	var exited bool
 	err := rows.Scan(
 		&node.ID,
 		&node.Address.Address, &node.Email, &node.Wallet, &node.LastNet, &lastIPPort, &countryCode, &node.PieceCount, &node.FreeDisk,
-		&node.Online, &node.Suspended, &node.Exiting, &node.Vetted)
+		&node.Online, &node.Suspended, &node.Exiting, &exited, &node.Vetted)
 	if err != nil {
 		return nodeselection.SelectedNode{}, err
 	}
@@ -953,6 +957,7 @@ func scanSelectedNode(rows tagsql.Rows) (nodeselection.SelectedNode, error) {
 	if countryCode.Valid {
 		node.CountryCode = location.ToCountryCode(countryCode.String)
 	}
+	_ = exited // SQL column is always false in GetAllParticipatingNodes; scanned for SELECT/Scan alignment
 	return node, nil
 }
 


### PR DESCRIPTION
What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
