### PR TITLE
Add google_backup_credentials table to database schema

### DIFF
--- a/satellite/satellitedb/dbx/oauth.dbx
+++ b/satellite/satellitedb/dbx/oauth.dbx
@@ -126,3 +126,50 @@ update oauth_token (
 	where oauth_token.kind = ?
 	noreturn
 )
+
+// google_backup_credentials stores Google OAuth tokens for backup and domain-users classification.
+model google_backup_credentials (
+	key id
+
+	unique user_id google_email
+
+	index (
+		name google_backup_credentials_user_id_index
+		fields user_id
+	)
+
+	// id is a UUID for this credential row.
+	field id                  blob
+	// user_id refers to user.id.
+	field user_id             user.id restrict
+	// google_email is the Google account email used for OAuth.
+	field google_email        text
+	// access_token is the Google OAuth access token.
+	field access_token        text       ( updatable )
+	// refresh_token is the Google OAuth refresh token for offline access.
+	field refresh_token       text       ( nullable, updatable )
+	// access_token_expiry is when the access token expires.
+	field access_token_expiry timestamp ( nullable, updatable )
+	// account_type is the workspace classification (personal, employee_workspace, admin_workspace).
+	field account_type        text       ( nullable, updatable )
+	// created_at indicates when the row was created.
+	field created_at          timestamp  ( autoinsert )
+	// updated_at indicates when the row was last updated.
+	field updated_at          timestamp  ( autoinsert, autoupdate )
+)
+
+create google_backup_credentials ( )
+
+update google_backup_credentials (
+	where google_backup_credentials.id = ?
+)
+
+read one (
+	select google_backup_credentials
+	where google_backup_credentials.id = ?
+)
+
+read all (
+	select google_backup_credentials
+	where google_backup_credentials.user_id = ?
+)

--- a/satellite/satellitedb/dbx/satellitedb.dbx.go
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.go
@@ -1275,6 +1275,20 @@ func (obj *pgxDB) Schema() []string {
 	PRIMARY KEY ( project_id, subdomain )
 )`,
 
+		`CREATE TABLE google_backup_credentials (
+	id bytea NOT NULL,
+	user_id bytea NOT NULL REFERENCES users( id ),
+	google_email text NOT NULL,
+	access_token text NOT NULL,
+	refresh_token text,
+	access_token_expiry timestamp with time zone,
+	account_type text,
+	created_at timestamp with time zone NOT NULL,
+	updated_at timestamp with time zone NOT NULL,
+	PRIMARY KEY ( id ),
+	UNIQUE ( user_id, google_email )
+)`,
+
 		`CREATE TABLE project_invitations (
 	project_id bytea NOT NULL REFERENCES projects( id ) ON DELETE CASCADE,
 	email text NOT NULL,
@@ -1438,6 +1452,8 @@ func (obj *pgxDB) Schema() []string {
 
 		`CREATE INDEX bucket_migrations_state_created_at_index ON bucket_migrations ( state, created_at )`,
 
+		`CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id )`,
+
 		`CREATE INDEX project_invitations_project_id_index ON project_invitations ( project_id )`,
 
 		`CREATE INDEX project_invitations_email_index ON project_invitations ( email )`,
@@ -1462,6 +1478,8 @@ func (obj *pgxDB) DropSchema() []string {
 		`DROP TABLE IF EXISTS project_members`,
 
 		`DROP TABLE IF EXISTS project_invitations`,
+
+		`DROP TABLE IF EXISTS google_backup_credentials`,
 
 		`DROP TABLE IF EXISTS domains`,
 
@@ -2619,6 +2637,20 @@ func (obj *pgxcockroachDB) Schema() []string {
 	PRIMARY KEY ( project_id, subdomain )
 )`,
 
+		`CREATE TABLE google_backup_credentials (
+	id bytea NOT NULL,
+	user_id bytea NOT NULL REFERENCES users( id ),
+	google_email text NOT NULL,
+	access_token text NOT NULL,
+	refresh_token text,
+	access_token_expiry timestamp with time zone,
+	account_type text,
+	created_at timestamp with time zone NOT NULL,
+	updated_at timestamp with time zone NOT NULL,
+	PRIMARY KEY ( id ),
+	UNIQUE ( user_id, google_email )
+)`,
+
 		`CREATE TABLE project_invitations (
 	project_id bytea NOT NULL REFERENCES projects( id ) ON DELETE CASCADE,
 	email text NOT NULL,
@@ -2782,6 +2814,8 @@ func (obj *pgxcockroachDB) Schema() []string {
 
 		`CREATE INDEX bucket_migrations_state_created_at_index ON bucket_migrations ( state, created_at )`,
 
+		`CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id )`,
+
 		`CREATE INDEX project_invitations_project_id_index ON project_invitations ( project_id )`,
 
 		`CREATE INDEX project_invitations_email_index ON project_invitations ( email )`,
@@ -2806,6 +2840,8 @@ func (obj *pgxcockroachDB) DropSchema() []string {
 		`DROP TABLE IF EXISTS project_members`,
 
 		`DROP TABLE IF EXISTS project_invitations`,
+
+		`DROP TABLE IF EXISTS google_backup_credentials`,
 
 		`DROP TABLE IF EXISTS domains`,
 
@@ -3916,6 +3952,21 @@ func (obj *spannerDB) Schema() []string {
 	CONSTRAINT domains_created_by_fkey FOREIGN KEY (created_by) REFERENCES users (id)
 ) PRIMARY KEY ( project_id, subdomain )`,
 
+		`CREATE TABLE google_backup_credentials (
+	id BYTES(MAX) NOT NULL,
+	user_id BYTES(MAX) NOT NULL,
+	google_email STRING(MAX) NOT NULL,
+	access_token STRING(MAX) NOT NULL,
+	refresh_token STRING(MAX),
+	access_token_expiry TIMESTAMP,
+	account_type STRING(MAX),
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	CONSTRAINT google_backup_credentials_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id)
+) PRIMARY KEY ( id )`,
+
+		`CREATE UNIQUE INDEX index_google_backup_credentials_user_id_google_email ON google_backup_credentials ( user_id, google_email )`,
+
 		`CREATE TABLE project_invitations (
 	project_id BYTES(MAX) NOT NULL,
 	email STRING(MAX) NOT NULL,
@@ -4082,6 +4133,8 @@ func (obj *spannerDB) Schema() []string {
 
 		`CREATE INDEX bucket_migrations_state_created_at_index ON bucket_migrations ( state, created_at )`,
 
+		`CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id )`,
+
 		`CREATE INDEX project_invitations_project_id_index ON project_invitations ( project_id )`,
 
 		`CREATE INDEX project_invitations_email_index ON project_invitations ( email )`,
@@ -4112,6 +4165,10 @@ func (obj *spannerDB) DropSchema() []string {
 		`ALTER TABLE project_invitations DROP CONSTRAINT project_invitations_project_id_fkey`,
 
 		`ALTER TABLE project_invitations DROP CONSTRAINT project_invitations_inviter_id_fkey`,
+
+		`ALTER TABLE google_backup_credentials DROP CONSTRAINT google_backup_credentials_user_id_fkey`,
+
+		`DROP INDEX IF EXISTS index_google_backup_credentials_user_id_google_email`,
 
 		`ALTER TABLE domains DROP CONSTRAINT domains_project_id_fkey`,
 
@@ -4265,6 +4322,8 @@ func (obj *spannerDB) DropSchema() []string {
 
 		`DROP INDEX IF EXISTS bucket_migrations_state_created_at_index`,
 
+		`DROP INDEX IF EXISTS google_backup_credentials_user_id_index`,
+
 		`DROP INDEX IF EXISTS project_invitations_project_id_index`,
 
 		`DROP INDEX IF EXISTS project_invitations_email_index`,
@@ -4312,6 +4371,12 @@ func (obj *spannerDB) DropSchema() []string {
 		`DROP SEQUENCE IF EXISTS project_invitations_email`,
 
 		`DROP TABLE IF EXISTS project_invitations`,
+
+		`ALTER TABLE  google_backup_credentials ALTER id SET DEFAULT (null)`,
+
+		`DROP SEQUENCE IF EXISTS google_backup_credentials_id`,
+
+		`DROP TABLE IF EXISTS google_backup_credentials`,
 
 		`ALTER TABLE  domains ALTER project_id SET DEFAULT (null)`,
 
@@ -19653,6 +19718,231 @@ func (f Domain_CreatedAt_Field) value() any {
 	return f._value
 }
 
+type GoogleBackupCredentials struct {
+	Id                []byte
+	UserId            []byte
+	GoogleEmail       string
+	AccessToken       string
+	RefreshToken      *string
+	AccessTokenExpiry *time.Time
+	AccountType       *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+func (GoogleBackupCredentials) _Table() string { return "google_backup_credentials" }
+
+type GoogleBackupCredentials_Create_Fields struct {
+	RefreshToken      GoogleBackupCredentials_RefreshToken_Field
+	AccessTokenExpiry GoogleBackupCredentials_AccessTokenExpiry_Field
+	AccountType       GoogleBackupCredentials_AccountType_Field
+}
+
+type GoogleBackupCredentials_Update_Fields struct {
+	AccessToken       GoogleBackupCredentials_AccessToken_Field
+	RefreshToken      GoogleBackupCredentials_RefreshToken_Field
+	AccessTokenExpiry GoogleBackupCredentials_AccessTokenExpiry_Field
+	AccountType       GoogleBackupCredentials_AccountType_Field
+}
+
+type GoogleBackupCredentials_Id_Field struct {
+	_set   bool
+	_null  bool
+	_value []byte
+}
+
+func GoogleBackupCredentials_Id(v []byte) GoogleBackupCredentials_Id_Field {
+	return GoogleBackupCredentials_Id_Field{_set: true, _value: v}
+}
+
+func (f GoogleBackupCredentials_Id_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_UserId_Field struct {
+	_set   bool
+	_null  bool
+	_value []byte
+}
+
+func GoogleBackupCredentials_UserId(v []byte) GoogleBackupCredentials_UserId_Field {
+	return GoogleBackupCredentials_UserId_Field{_set: true, _value: v}
+}
+
+func (f GoogleBackupCredentials_UserId_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_GoogleEmail_Field struct {
+	_set   bool
+	_null  bool
+	_value string
+}
+
+func GoogleBackupCredentials_GoogleEmail(v string) GoogleBackupCredentials_GoogleEmail_Field {
+	return GoogleBackupCredentials_GoogleEmail_Field{_set: true, _value: v}
+}
+
+func (f GoogleBackupCredentials_GoogleEmail_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_AccessToken_Field struct {
+	_set   bool
+	_null  bool
+	_value string
+}
+
+func GoogleBackupCredentials_AccessToken(v string) GoogleBackupCredentials_AccessToken_Field {
+	return GoogleBackupCredentials_AccessToken_Field{_set: true, _value: v}
+}
+
+func (f GoogleBackupCredentials_AccessToken_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_RefreshToken_Field struct {
+	_set   bool
+	_null  bool
+	_value *string
+}
+
+func GoogleBackupCredentials_RefreshToken(v string) GoogleBackupCredentials_RefreshToken_Field {
+	return GoogleBackupCredentials_RefreshToken_Field{_set: true, _value: &v}
+}
+
+func GoogleBackupCredentials_RefreshToken_Raw(v *string) GoogleBackupCredentials_RefreshToken_Field {
+	if v == nil {
+		return GoogleBackupCredentials_RefreshToken_Null()
+	}
+	return GoogleBackupCredentials_RefreshToken(*v)
+}
+
+func GoogleBackupCredentials_RefreshToken_Null() GoogleBackupCredentials_RefreshToken_Field {
+	return GoogleBackupCredentials_RefreshToken_Field{_set: true, _null: true}
+}
+
+func (f GoogleBackupCredentials_RefreshToken_Field) isnull() bool {
+	return !f._set || f._null || f._value == nil
+}
+
+func (f GoogleBackupCredentials_RefreshToken_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_AccessTokenExpiry_Field struct {
+	_set   bool
+	_null  bool
+	_value *time.Time
+}
+
+func GoogleBackupCredentials_AccessTokenExpiry(v time.Time) GoogleBackupCredentials_AccessTokenExpiry_Field {
+	return GoogleBackupCredentials_AccessTokenExpiry_Field{_set: true, _value: &v}
+}
+
+func GoogleBackupCredentials_AccessTokenExpiry_Raw(v *time.Time) GoogleBackupCredentials_AccessTokenExpiry_Field {
+	if v == nil {
+		return GoogleBackupCredentials_AccessTokenExpiry_Null()
+	}
+	return GoogleBackupCredentials_AccessTokenExpiry(*v)
+}
+
+func GoogleBackupCredentials_AccessTokenExpiry_Null() GoogleBackupCredentials_AccessTokenExpiry_Field {
+	return GoogleBackupCredentials_AccessTokenExpiry_Field{_set: true, _null: true}
+}
+
+func (f GoogleBackupCredentials_AccessTokenExpiry_Field) isnull() bool {
+	return !f._set || f._null || f._value == nil
+}
+
+func (f GoogleBackupCredentials_AccessTokenExpiry_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_AccountType_Field struct {
+	_set   bool
+	_null  bool
+	_value *string
+}
+
+func GoogleBackupCredentials_AccountType(v string) GoogleBackupCredentials_AccountType_Field {
+	return GoogleBackupCredentials_AccountType_Field{_set: true, _value: &v}
+}
+
+func GoogleBackupCredentials_AccountType_Raw(v *string) GoogleBackupCredentials_AccountType_Field {
+	if v == nil {
+		return GoogleBackupCredentials_AccountType_Null()
+	}
+	return GoogleBackupCredentials_AccountType(*v)
+}
+
+func GoogleBackupCredentials_AccountType_Null() GoogleBackupCredentials_AccountType_Field {
+	return GoogleBackupCredentials_AccountType_Field{_set: true, _null: true}
+}
+
+func (f GoogleBackupCredentials_AccountType_Field) isnull() bool {
+	return !f._set || f._null || f._value == nil
+}
+
+func (f GoogleBackupCredentials_AccountType_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_CreatedAt_Field struct {
+	_set   bool
+	_null  bool
+	_value time.Time
+}
+
+func GoogleBackupCredentials_CreatedAt(v time.Time) GoogleBackupCredentials_CreatedAt_Field {
+	return GoogleBackupCredentials_CreatedAt_Field{_set: true, _value: v}
+}
+
+func (f GoogleBackupCredentials_CreatedAt_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
+type GoogleBackupCredentials_UpdatedAt_Field struct {
+	_set   bool
+	_null  bool
+	_value time.Time
+}
+
+func GoogleBackupCredentials_UpdatedAt(v time.Time) GoogleBackupCredentials_UpdatedAt_Field {
+	return GoogleBackupCredentials_UpdatedAt_Field{_set: true, _value: v}
+}
+
+func (f GoogleBackupCredentials_UpdatedAt_Field) value() any {
+	if !f._set || f._null {
+		return nil
+	}
+	return f._value
+}
+
 type ProjectInvitation struct {
 	ProjectId []byte
 	Email     string
@@ -22494,6 +22784,46 @@ func (obj *pgxImpl) CreateNoReturn_OauthToken(ctx context.Context,
 		return obj.makeErr(err)
 	}
 	return nil
+
+}
+
+func (obj *pgxImpl) Create_GoogleBackupCredentials(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+	google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field,
+	google_backup_credentials_google_email GoogleBackupCredentials_GoogleEmail_Field,
+	google_backup_credentials_access_token GoogleBackupCredentials_AccessToken_Field,
+	optional GoogleBackupCredentials_Create_Fields) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	__now := obj.db.Hooks.Now().UTC()
+	__id_val := google_backup_credentials_id.value()
+	__user_id_val := google_backup_credentials_user_id.value()
+	__google_email_val := google_backup_credentials_google_email.value()
+	__access_token_val := google_backup_credentials_access_token.value()
+	__refresh_token_val := optional.RefreshToken.value()
+	__access_token_expiry_val := optional.AccessTokenExpiry.value()
+	__account_type_val := optional.AccountType.value()
+	__created_at_val := __now
+	__updated_at_val := __now
+
+	var __embed_stmt = __sqlbundle_Literal("INSERT INTO google_backup_credentials ( id, user_id, google_email, access_token, refresh_token, access_token_expiry, account_type, created_at, updated_at ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ? ) RETURNING google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at")
+
+	var __values []any
+	__values = append(__values, __id_val, __user_id_val, __google_email_val, __access_token_val, __refresh_token_val, __access_token_expiry_val, __account_type_val, __created_at_val, __updated_at_val)
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
 
 }
 
@@ -28020,6 +28350,76 @@ func (obj *pgxImpl) Get_OauthToken_By_Kind_And_Token(ctx context.Context,
 		return (*OauthToken)(nil), obj.makeErr(err)
 	}
 	return oauth_token, nil
+
+}
+
+func (obj *pgxImpl) Get_GoogleBackupCredentials_By_Id(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at FROM google_backup_credentials WHERE google_backup_credentials.id = ?")
+
+	var __values []any
+	__values = append(__values, google_backup_credentials_id.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err != nil {
+		return (*GoogleBackupCredentials)(nil), obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
+
+}
+
+func (obj *pgxImpl) All_GoogleBackupCredentials_By_UserId(ctx context.Context,
+	google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field) (
+	rows []*GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at FROM google_backup_credentials WHERE google_backup_credentials.user_id = ?")
+
+	var __values []any
+	__values = append(__values, google_backup_credentials_user_id.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	for {
+		rows, err = func() (rows []*GoogleBackupCredentials, err error) {
+			__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+			if err != nil {
+				return nil, err
+			}
+			defer closeRows(__rows, &err)
+
+			for __rows.Next() {
+				google_backup_credentials := &GoogleBackupCredentials{}
+				err = __rows.Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+				if err != nil {
+					return nil, err
+				}
+				rows = append(rows, google_backup_credentials)
+			}
+			return rows, nil
+		}()
+		if err != nil {
+			if obj.shouldRetry(err) {
+				continue
+			}
+			return nil, obj.makeErr(err)
+		}
+		return rows, nil
+	}
 
 }
 
@@ -33620,6 +34020,67 @@ func (obj *pgxImpl) UpdateNoReturn_OauthToken_By_Token_And_Kind(ctx context.Cont
 	return nil
 }
 
+func (obj *pgxImpl) Update_GoogleBackupCredentials_By_Id(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+	update GoogleBackupCredentials_Update_Fields) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __sets = &__sqlbundle_Hole{}
+
+	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("UPDATE google_backup_credentials SET "), __sets, __sqlbundle_Literal(" WHERE google_backup_credentials.id = ? RETURNING google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at")}}
+
+	__sets_sql := __sqlbundle_Literals{Join: ", "}
+	var __values []any
+	var __args []any
+
+	if update.AccessToken._set {
+		__values = append(__values, update.AccessToken.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("access_token = ?"))
+	}
+
+	if update.RefreshToken._set {
+		__values = append(__values, update.RefreshToken.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("refresh_token = ?"))
+	}
+
+	if update.AccessTokenExpiry._set {
+		__values = append(__values, update.AccessTokenExpiry.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("access_token_expiry = ?"))
+	}
+
+	if update.AccountType._set {
+		__values = append(__values, update.AccountType.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("account_type = ?"))
+	}
+
+	__now := obj.db.Hooks.Now().UTC()
+
+	__values = append(__values, __now)
+	__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("updated_at = ?"))
+
+	__args = append(__args, google_backup_credentials_id.value())
+
+	__values = append(__values, __args...)
+	__sets.SQL = __sets_sql
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
+}
+
 func (obj *pgxImpl) Update_Project_By_Id(ctx context.Context,
 	project_id Project_Id_Field,
 	update Project_Update_Fields) (
@@ -36765,6 +37226,16 @@ func (obj *pgxImpl) deleteAll(ctx context.Context) (count int64, err error) {
 		return 0, obj.makeErr(err)
 	}
 	count += __count
+	__res, err = obj.driver.ExecContext(ctx, "DELETE FROM google_backup_credentials;")
+	if err != nil {
+		return 0, obj.makeErr(err)
+	}
+
+	__count, err = __res.RowsAffected()
+	if err != nil {
+		return 0, obj.makeErr(err)
+	}
+	count += __count
 	__res, err = obj.driver.ExecContext(ctx, "DELETE FROM domains;")
 	if err != nil {
 		return 0, obj.makeErr(err)
@@ -39187,6 +39658,46 @@ func (obj *pgxcockroachImpl) CreateNoReturn_OauthToken(ctx context.Context,
 		return obj.makeErr(err)
 	}
 	return nil
+
+}
+
+func (obj *pgxcockroachImpl) Create_GoogleBackupCredentials(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+	google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field,
+	google_backup_credentials_google_email GoogleBackupCredentials_GoogleEmail_Field,
+	google_backup_credentials_access_token GoogleBackupCredentials_AccessToken_Field,
+	optional GoogleBackupCredentials_Create_Fields) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	__now := obj.db.Hooks.Now().UTC()
+	__id_val := google_backup_credentials_id.value()
+	__user_id_val := google_backup_credentials_user_id.value()
+	__google_email_val := google_backup_credentials_google_email.value()
+	__access_token_val := google_backup_credentials_access_token.value()
+	__refresh_token_val := optional.RefreshToken.value()
+	__access_token_expiry_val := optional.AccessTokenExpiry.value()
+	__account_type_val := optional.AccountType.value()
+	__created_at_val := __now
+	__updated_at_val := __now
+
+	var __embed_stmt = __sqlbundle_Literal("INSERT INTO google_backup_credentials ( id, user_id, google_email, access_token, refresh_token, access_token_expiry, account_type, created_at, updated_at ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ? ) RETURNING google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at")
+
+	var __values []any
+	__values = append(__values, __id_val, __user_id_val, __google_email_val, __access_token_val, __refresh_token_val, __access_token_expiry_val, __account_type_val, __created_at_val, __updated_at_val)
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
 
 }
 
@@ -44713,6 +45224,76 @@ func (obj *pgxcockroachImpl) Get_OauthToken_By_Kind_And_Token(ctx context.Contex
 		return (*OauthToken)(nil), obj.makeErr(err)
 	}
 	return oauth_token, nil
+
+}
+
+func (obj *pgxcockroachImpl) Get_GoogleBackupCredentials_By_Id(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at FROM google_backup_credentials WHERE google_backup_credentials.id = ?")
+
+	var __values []any
+	__values = append(__values, google_backup_credentials_id.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err != nil {
+		return (*GoogleBackupCredentials)(nil), obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
+
+}
+
+func (obj *pgxcockroachImpl) All_GoogleBackupCredentials_By_UserId(ctx context.Context,
+	google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field) (
+	rows []*GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at FROM google_backup_credentials WHERE google_backup_credentials.user_id = ?")
+
+	var __values []any
+	__values = append(__values, google_backup_credentials_user_id.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	for {
+		rows, err = func() (rows []*GoogleBackupCredentials, err error) {
+			__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+			if err != nil {
+				return nil, err
+			}
+			defer closeRows(__rows, &err)
+
+			for __rows.Next() {
+				google_backup_credentials := &GoogleBackupCredentials{}
+				err = __rows.Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+				if err != nil {
+					return nil, err
+				}
+				rows = append(rows, google_backup_credentials)
+			}
+			return rows, nil
+		}()
+		if err != nil {
+			if obj.shouldRetry(err) {
+				continue
+			}
+			return nil, obj.makeErr(err)
+		}
+		return rows, nil
+	}
 
 }
 
@@ -50313,6 +50894,67 @@ func (obj *pgxcockroachImpl) UpdateNoReturn_OauthToken_By_Token_And_Kind(ctx con
 	return nil
 }
 
+func (obj *pgxcockroachImpl) Update_GoogleBackupCredentials_By_Id(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+	update GoogleBackupCredentials_Update_Fields) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __sets = &__sqlbundle_Hole{}
+
+	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("UPDATE google_backup_credentials SET "), __sets, __sqlbundle_Literal(" WHERE google_backup_credentials.id = ? RETURNING google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at")}}
+
+	__sets_sql := __sqlbundle_Literals{Join: ", "}
+	var __values []any
+	var __args []any
+
+	if update.AccessToken._set {
+		__values = append(__values, update.AccessToken.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("access_token = ?"))
+	}
+
+	if update.RefreshToken._set {
+		__values = append(__values, update.RefreshToken.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("refresh_token = ?"))
+	}
+
+	if update.AccessTokenExpiry._set {
+		__values = append(__values, update.AccessTokenExpiry.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("access_token_expiry = ?"))
+	}
+
+	if update.AccountType._set {
+		__values = append(__values, update.AccountType.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("account_type = ?"))
+	}
+
+	__now := obj.db.Hooks.Now().UTC()
+
+	__values = append(__values, __now)
+	__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("updated_at = ?"))
+
+	__args = append(__args, google_backup_credentials_id.value())
+
+	__values = append(__values, __args...)
+	__sets.SQL = __sets_sql
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
+}
+
 func (obj *pgxcockroachImpl) Update_Project_By_Id(ctx context.Context,
 	project_id Project_Id_Field,
 	update Project_Update_Fields) (
@@ -53458,6 +54100,16 @@ func (obj *pgxcockroachImpl) deleteAll(ctx context.Context) (count int64, err er
 		return 0, obj.makeErr(err)
 	}
 	count += __count
+	__res, err = obj.driver.ExecContext(ctx, "DELETE FROM google_backup_credentials;")
+	if err != nil {
+		return 0, obj.makeErr(err)
+	}
+
+	__count, err = __res.RowsAffected()
+	if err != nil {
+		return 0, obj.makeErr(err)
+	}
+	count += __count
 	__res, err = obj.driver.ExecContext(ctx, "DELETE FROM domains;")
 	if err != nil {
 		return 0, obj.makeErr(err)
@@ -56094,6 +56746,52 @@ func (obj *spannerImpl) CreateNoReturn_OauthToken(ctx context.Context,
 		return obj.makeErr(err)
 	}
 	return nil
+
+}
+
+func (obj *spannerImpl) Create_GoogleBackupCredentials(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+	google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field,
+	google_backup_credentials_google_email GoogleBackupCredentials_GoogleEmail_Field,
+	google_backup_credentials_access_token GoogleBackupCredentials_AccessToken_Field,
+	optional GoogleBackupCredentials_Create_Fields) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	__now := obj.db.Hooks.Now().UTC()
+	__id_val := google_backup_credentials_id.value()
+	__user_id_val := google_backup_credentials_user_id.value()
+	__google_email_val := google_backup_credentials_google_email.value()
+	__access_token_val := google_backup_credentials_access_token.value()
+	__refresh_token_val := optional.RefreshToken.value()
+	__access_token_expiry_val := optional.AccessTokenExpiry.value()
+	__account_type_val := optional.AccountType.value()
+	__created_at_val := __now
+	__updated_at_val := __now
+
+	var __embed_stmt = __sqlbundle_Literal("INSERT INTO google_backup_credentials ( id, user_id, google_email, access_token, refresh_token, access_token_expiry, account_type, created_at, updated_at ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ? ) THEN RETURN google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at")
+
+	var __values []any
+	__values = append(__values, __id_val, __user_id_val, __google_email_val, __access_token_val, __refresh_token_val, __access_token_expiry_val, __account_type_val, __created_at_val, __updated_at_val)
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	if !obj.txn {
+		err = obj.withTx(ctx, func(tx tagsql.Tx) error {
+			return tx.QueryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+		})
+	} else {
+		err = obj.driver.QueryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	}
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
 
 }
 
@@ -61836,6 +62534,76 @@ func (obj *spannerImpl) Get_OauthToken_By_Kind_And_Token(ctx context.Context,
 
 }
 
+func (obj *spannerImpl) Get_GoogleBackupCredentials_By_Id(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at FROM google_backup_credentials WHERE google_backup_credentials.id = ?")
+
+	var __values []any
+	__values = append(__values, google_backup_credentials_id.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.queryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if err != nil {
+		return (*GoogleBackupCredentials)(nil), obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
+
+}
+
+func (obj *spannerImpl) All_GoogleBackupCredentials_By_UserId(ctx context.Context,
+	google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field) (
+	rows []*GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at FROM google_backup_credentials WHERE google_backup_credentials.user_id = ?")
+
+	var __values []any
+	__values = append(__values, google_backup_credentials_user_id.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	for {
+		rows, err = func() (rows []*GoogleBackupCredentials, err error) {
+			__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+			if err != nil {
+				return nil, err
+			}
+			defer closeRows(__rows, &err)
+
+			for __rows.Next() {
+				google_backup_credentials := &GoogleBackupCredentials{}
+				err = __rows.Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+				if err != nil {
+					return nil, err
+				}
+				rows = append(rows, google_backup_credentials)
+			}
+			return rows, nil
+		}()
+		if err != nil {
+			if obj.shouldRetry(err) {
+				continue
+			}
+			return nil, obj.makeErr(err)
+		}
+		return rows, nil
+	}
+
+}
+
 func (obj *spannerImpl) Get_Project_PassphraseEnc_Project_PassphraseEncKeyId_By_Id(ctx context.Context,
 	project_id Project_Id_Field) (
 	row *PassphraseEnc_PassphraseEncKeyId_Row, err error) {
@@ -67227,6 +67995,64 @@ func (obj *spannerImpl) UpdateNoReturn_OauthToken_By_Token_And_Kind(ctx context.
 	return nil
 }
 
+func (obj *spannerImpl) Update_GoogleBackupCredentials_By_Id(ctx context.Context,
+	google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+	update GoogleBackupCredentials_Update_Fields) (
+	google_backup_credentials *GoogleBackupCredentials, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if !obj.txn && txutil.IsInsideTx(ctx) {
+		panic("using DB when inside of a transaction")
+	}
+
+	var __sets = &__sqlbundle_Hole{}
+
+	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("UPDATE google_backup_credentials SET "), __sets, __sqlbundle_Literal(" WHERE google_backup_credentials.id = ? THEN RETURN google_backup_credentials.id, google_backup_credentials.user_id, google_backup_credentials.google_email, google_backup_credentials.access_token, google_backup_credentials.refresh_token, google_backup_credentials.access_token_expiry, google_backup_credentials.account_type, google_backup_credentials.created_at, google_backup_credentials.updated_at")}}
+
+	__sets_sql := __sqlbundle_Literals{Join: ", "}
+	var __values []any
+	var __args []any
+
+	if update.AccessToken._set {
+		__values = append(__values, update.AccessToken.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("access_token = ?"))
+	}
+	if update.RefreshToken._set {
+		__values = append(__values, update.RefreshToken.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("refresh_token = ?"))
+	}
+	if update.AccessTokenExpiry._set {
+		__values = append(__values, update.AccessTokenExpiry.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("access_token_expiry = ?"))
+	}
+	if update.AccountType._set {
+		__values = append(__values, update.AccountType.value())
+		__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("account_type = ?"))
+	}
+
+	__now := obj.db.Hooks.Now().UTC()
+
+	__values = append(__values, __now)
+	__sets_sql.SQLs = append(__sets_sql.SQLs, __sqlbundle_Literal("updated_at = ?"))
+
+	__args = append(__args, google_backup_credentials_id.value())
+
+	__values = append(__values, __args...)
+	__sets.SQL = __sets_sql
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	google_backup_credentials = &GoogleBackupCredentials{}
+	err = obj.driver.QueryRowContext(ctx, __stmt, __values...).Scan(&google_backup_credentials.Id, &google_backup_credentials.UserId, &google_backup_credentials.GoogleEmail, &google_backup_credentials.AccessToken, &google_backup_credentials.RefreshToken, &google_backup_credentials.AccessTokenExpiry, &google_backup_credentials.AccountType, &google_backup_credentials.CreatedAt, &google_backup_credentials.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return google_backup_credentials, nil
+}
+
 func (obj *spannerImpl) Update_Project_By_Id(ctx context.Context,
 	project_id Project_Id_Field,
 	update Project_Update_Fields) (
@@ -70207,6 +71033,16 @@ func (obj *spannerImpl) deleteAll(ctx context.Context) (count int64, err error) 
 		return 0, obj.makeErr(err)
 	}
 	count += __count
+	__res, err = obj.driver.ExecContext(ctx, "DELETE FROM google_backup_credentials;")
+	if err != nil {
+		return 0, obj.makeErr(err)
+	}
+
+	__count, err = __res.RowsAffected()
+	if err != nil {
+		return 0, obj.makeErr(err)
+	}
+	count += __count
 	__res, err = obj.driver.ExecContext(ctx, "DELETE FROM domains;")
 	if err != nil {
 		return 0, obj.makeErr(err)
@@ -71028,6 +71864,10 @@ type Methods interface {
 		fcm_tokens_user_id FcmTokens_UserId_Field) (
 		rows []*FcmTokens, err error)
 
+	All_GoogleBackupCredentials_By_UserId(ctx context.Context,
+		google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field) (
+		rows []*GoogleBackupCredentials, err error)
+
 	All_NodeSmartContractUpdates(ctx context.Context) (
 		rows []*NodeSmartContractUpdates, err error)
 
@@ -71457,6 +72297,14 @@ type Methods interface {
 		fcm_tokens_updated_at FcmTokens_UpdatedAt_Field,
 		optional FcmTokens_Create_Fields) (
 		fcm_tokens *FcmTokens, err error)
+
+	Create_GoogleBackupCredentials(ctx context.Context,
+		google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+		google_backup_credentials_user_id GoogleBackupCredentials_UserId_Field,
+		google_backup_credentials_google_email GoogleBackupCredentials_GoogleEmail_Field,
+		google_backup_credentials_access_token GoogleBackupCredentials_AccessToken_Field,
+		optional GoogleBackupCredentials_Create_Fields) (
+		google_backup_credentials *GoogleBackupCredentials, err error)
 
 	Create_NodeEvent(ctx context.Context,
 		node_event_id NodeEvent_Id_Field,
@@ -72001,6 +72849,10 @@ type Methods interface {
 	Get_FcmTokens_By_Token(ctx context.Context,
 		fcm_tokens_token FcmTokens_Token_Field) (
 		fcm_tokens *FcmTokens, err error)
+
+	Get_GoogleBackupCredentials_By_Id(ctx context.Context,
+		google_backup_credentials_id GoogleBackupCredentials_Id_Field) (
+		google_backup_credentials *GoogleBackupCredentials, err error)
 
 	Get_KeyVersion_Version_By_KeyId(ctx context.Context,
 		key_version_key_id KeyVersion_KeyId_Field) (
@@ -72622,6 +73474,11 @@ type Methods interface {
 		fcm_tokens_id FcmTokens_Id_Field,
 		update FcmTokens_Update_Fields) (
 		fcm_tokens *FcmTokens, err error)
+
+	Update_GoogleBackupCredentials_By_Id(ctx context.Context,
+		google_backup_credentials_id GoogleBackupCredentials_Id_Field,
+		update GoogleBackupCredentials_Update_Fields) (
+		google_backup_credentials *GoogleBackupCredentials, err error)
 
 	Update_KeyVersion_By_KeyId(ctx context.Context,
 		key_version_key_id KeyVersion_KeyId_Field,

--- a/satellite/satellitedb/dbx/satellitedb.dbx.pgx.sql
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.pgx.sql
@@ -848,6 +848,19 @@ CREATE TABLE domains (
 	created_at timestamp with time zone NOT NULL,
 	PRIMARY KEY ( project_id, subdomain )
 ) ;
+CREATE TABLE google_backup_credentials (
+	id bytea NOT NULL,
+	user_id bytea NOT NULL REFERENCES users( id ),
+	google_email text NOT NULL,
+	access_token text NOT NULL,
+	refresh_token text,
+	access_token_expiry timestamp with time zone,
+	account_type text,
+	created_at timestamp with time zone NOT NULL,
+	updated_at timestamp with time zone NOT NULL,
+	PRIMARY KEY ( id ),
+	UNIQUE ( user_id, google_email )
+) ;
 CREATE TABLE project_invitations (
 	project_id bytea NOT NULL REFERENCES projects( id ) ON DELETE CASCADE,
 	email text NOT NULL,
@@ -946,6 +959,7 @@ CREATE INDEX user_delete_requests_user_id_index ON user_delete_requests ( user_i
 CREATE INDEX webapp_sessions_user_id_index ON webapp_sessions ( user_id ) ;
 CREATE INDEX webapp_session_developers_developer_id_index ON webapp_session_developers ( developer_id ) ;
 CREATE INDEX bucket_migrations_state_created_at_index ON bucket_migrations ( state, created_at ) ;
+CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id ) ;
 CREATE INDEX project_invitations_project_id_index ON project_invitations ( project_id ) ;
 CREATE INDEX project_invitations_email_index ON project_invitations ( email ) ;
 CREATE INDEX project_members_project_id_index ON project_members ( project_id ) ;

--- a/satellite/satellitedb/dbx/satellitedb.dbx.pgxcockroach.sql
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.pgxcockroach.sql
@@ -848,6 +848,19 @@ CREATE TABLE domains (
 	created_at timestamp with time zone NOT NULL,
 	PRIMARY KEY ( project_id, subdomain )
 ) ;
+CREATE TABLE google_backup_credentials (
+	id bytea NOT NULL,
+	user_id bytea NOT NULL REFERENCES users( id ),
+	google_email text NOT NULL,
+	access_token text NOT NULL,
+	refresh_token text,
+	access_token_expiry timestamp with time zone,
+	account_type text,
+	created_at timestamp with time zone NOT NULL,
+	updated_at timestamp with time zone NOT NULL,
+	PRIMARY KEY ( id ),
+	UNIQUE ( user_id, google_email )
+) ;
 CREATE TABLE project_invitations (
 	project_id bytea NOT NULL REFERENCES projects( id ) ON DELETE CASCADE,
 	email text NOT NULL,
@@ -946,6 +959,7 @@ CREATE INDEX user_delete_requests_user_id_index ON user_delete_requests ( user_i
 CREATE INDEX webapp_sessions_user_id_index ON webapp_sessions ( user_id ) ;
 CREATE INDEX webapp_session_developers_developer_id_index ON webapp_session_developers ( developer_id ) ;
 CREATE INDEX bucket_migrations_state_created_at_index ON bucket_migrations ( state, created_at ) ;
+CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id ) ;
 CREATE INDEX project_invitations_project_id_index ON project_invitations ( project_id ) ;
 CREATE INDEX project_invitations_email_index ON project_invitations ( email ) ;
 CREATE INDEX project_members_project_id_index ON project_members ( project_id ) ;

--- a/satellite/satellitedb/dbx/satellitedb.dbx.spanner.sql
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.spanner.sql
@@ -789,6 +789,19 @@ CREATE TABLE domains (
 	CONSTRAINT domains_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id),
 	CONSTRAINT domains_created_by_fkey FOREIGN KEY (created_by) REFERENCES users (id)
 ) PRIMARY KEY ( project_id, subdomain ) ;
+CREATE TABLE google_backup_credentials (
+	id BYTES(MAX) NOT NULL,
+	user_id BYTES(MAX) NOT NULL,
+	google_email STRING(MAX) NOT NULL,
+	access_token STRING(MAX) NOT NULL,
+	refresh_token STRING(MAX),
+	access_token_expiry TIMESTAMP,
+	account_type STRING(MAX),
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	CONSTRAINT google_backup_credentials_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id)
+) PRIMARY KEY ( id ) ;
+CREATE UNIQUE INDEX index_google_backup_credentials_user_id_google_email ON google_backup_credentials ( user_id, google_email ) ;
 CREATE TABLE project_invitations (
 	project_id BYTES(MAX) NOT NULL,
 	email STRING(MAX) NOT NULL,
@@ -889,6 +902,7 @@ CREATE INDEX user_delete_requests_user_id_index ON user_delete_requests ( user_i
 CREATE INDEX webapp_sessions_user_id_index ON webapp_sessions ( user_id ) ;
 CREATE INDEX webapp_session_developers_developer_id_index ON webapp_session_developers ( developer_id ) ;
 CREATE INDEX bucket_migrations_state_created_at_index ON bucket_migrations ( state, created_at ) ;
+CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id ) ;
 CREATE INDEX project_invitations_project_id_index ON project_invitations ( project_id ) ;
 CREATE INDEX project_invitations_email_index ON project_invitations ( email ) ;
 CREATE INDEX project_members_project_id_index ON project_members ( project_id ) ;

--- a/satellite/satellitedb/migrate.go
+++ b/satellite/satellitedb/migrate.go
@@ -1178,6 +1178,26 @@ func (db *satelliteDB) productionMigrationSpanner() *migrate.Migration {
 					`CREATE INDEX retention_remainder_charges_project_id_deleted_at_billed_index ON retention_remainder_charges ( project_id, deleted_at, billed ) ;`,
 				},
 			},
+			{
+				DB:          &db.migrationDB,
+				Description: "add google_backup_credentials table",
+				Version:     129,
+				Action: migrate.SQL{
+					`CREATE TABLE google_backup_credentials (
+						id BYTES(MAX) NOT NULL,
+						user_id BYTES(MAX) NOT NULL,
+						google_email STRING(MAX) NOT NULL,
+						access_token STRING(MAX) NOT NULL,
+						refresh_token STRING(MAX),
+						access_token_expiry TIMESTAMP,
+						account_type STRING(MAX),
+						created_at TIMESTAMP NOT NULL,
+						updated_at TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = TRUE)
+					) PRIMARY KEY ( id )`,
+					`CREATE UNIQUE INDEX google_backup_credentials_user_id_google_email_unique ON google_backup_credentials ( user_id, google_email )`,
+					`CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id )`,
+				},
+			},
 			// NB: after updating testdata in `testdata`, run
 			//     `go generate` to update `migratez.go`.
 		},
@@ -4954,6 +4974,27 @@ true, NOW(), NOW());`,
 						PRIMARY KEY ( project_id, bucket_name, deleted_at )
 					);`,
 					`CREATE INDEX retention_remainder_charges_project_id_deleted_at_billed_index ON retention_remainder_charges ( project_id, deleted_at, billed ) ;`,
+				},
+			},
+			{
+				DB:          &db.migrationDB,
+				Description: "add google_backup_credentials table",
+				Version:     373,
+				Action: migrate.SQL{
+					`CREATE TABLE google_backup_credentials (
+						id bytea NOT NULL,
+						user_id bytea NOT NULL,
+						google_email text NOT NULL,
+						access_token text NOT NULL,
+						refresh_token text,
+						access_token_expiry timestamp with time zone,
+						account_type text,
+						created_at timestamp with time zone NOT NULL,
+						updated_at timestamp with time zone NOT NULL,
+						PRIMARY KEY ( id ),
+						UNIQUE ( user_id, google_email )
+					);`,
+					`CREATE INDEX google_backup_credentials_user_id_index ON google_backup_credentials ( user_id );`,
 				},
 			},
 			// NB: after updating testdata in `testdata`, run


### PR DESCRIPTION
- Introduced a new table `google_backup_credentials` to store Google OAuth tokens, including fields for user ID, email, access tokens, and timestamps for creation and updates.
- Created unique and standard indexes for efficient querying on user ID and email.
- Updated migration scripts and database schema files to reflect these changes across different database systems (PostgreSQL, CockroachDB, Spanner).
- Enhanced the overall database structure to support better management of Google OAuth credentials for users.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storxnetwork/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storxnetwork/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storxnetwork/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
